### PR TITLE
List actions by resource type

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -11,22 +11,22 @@ APPSECRET="5bce2ce904d5f8:Mjg2ODA3NTU0MjAzNTAzMTU1ODI3MzE5Mzg3MTU3Mjk5MjA"
 ### create
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules' -d \
-'{"name":"test-rule","for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"default:debug_action","params":{"a":1}}],"description":"test-rule"}'
+'{"name":"test-rule","for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"built_in:inspect_action","params":{"a":1}}],"description":"test-rule"}'
 
-{"code":0,"data":{"actions":[{"name":"default:debug_action","params":{"a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120126626615666","name":"test-rule","rawsql":"select * from \"t/a\""}}
+{"code":0,"data":{"actions":[{"name":"built_in:inspect_action","params":{"a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120126626615666","name":"test-rule","rawsql":"select * from \"t/a\""}}
 
 ## with a resource id in the action args
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules' -d \
-'{"name":"test-rule","for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"default:debug_action","params":{"$resource":"debug_resource_type:test-resource","a":1}}],"description":"test-rule"}'
+'{"name":"test-rule","for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule"}'
 
-{"code":0,"data":{"actions":[{"name":"default:debug_action","params":{"$resource":"debug_resource_type:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}}
+{"code":0,"data":{"actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}}
 ```
 
 ### show
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/test-rule:1555120233443199609'
 
-{"code":0,"data":{"actions":[{"name":"default:debug_action","params":{"$resource":"debug_resource_type:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}}
+{"code":0,"data":{"actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}}
 ```
 
 ### list
@@ -34,7 +34,7 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/test-rule
 ```shell
 $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/rules
 
-{"code":0,"data":[{"actions":[{"name":"default:debug_action","params":{"a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120126626615666","name":"test-rule","rawsql":"select * from \"t/a\""},{"actions":[{"name":"default:debug_action","params":{"$resource":"debug_resource_type:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}]}
+{"code":0,"data":[{"actions":[{"name":"built_in:inspect_action","params":{"a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120126626615666","name":"test-rule","rawsql":"select * from \"t/a\""},{"actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}]}
 ```
 
 ### delete
@@ -54,7 +54,7 @@ $ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/
 ```shell
 $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/actions
 
-{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","name":"default:debug_action","params":{"$resource":"debug_resource_type"}},{"app":"emqx_rule_engine","description":"Republish a MQTT message","name":"default:republish_message","params":{"$resource":"debug_resource_type","from":"topic","to":"topic"}}]}
+{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{"$resource":"built_in"}},{"app":"emqx_rule_engine","description":"Republish a MQTT message","name":"built_in:republish_message","params":{"$resource":"built_in","from":"topic","to":"topic"}}]}
 ```
 
 
@@ -62,9 +62,9 @@ $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/actions
 ### show
 
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions/default:debug_action'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions/built_in:inspect_action'
 
-{"code":0,"data":{"app":"emqx_rule_engine","description":"Debug Action","name":"default:debug_action","params":{"$resource":"debug_resource_type"}}}
+{"code":0,"data":{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{"$resource":"built_in"}}}
 ```
 
 
@@ -76,23 +76,23 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions/default
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types'
 
-{"code":0,"data":[{"description":"Debug resource type","name":"debug_resource_type","params":{},"provider":"emqx_rule_engine"}]}
+{"code":0,"data":[{"description":"Debug resource type","name":"built_in","params":{},"provider":"emqx_rule_engine"}]}
 ```
 
 ### list all resources of a type
 
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/debug_resource_type/resources'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/built_in/resources'
 
-{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"debug_resource_type:test-resource","name":"test-resource","type":"debug_resource_type"}]}
+{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}]}
 ```
 
 ### show
 
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/debug_resource_type'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/built_in'
 
-{"code":0,"data":{"description":"Debug resource type","name":"debug_resource_type","params":{},"provider":"emqx_rule_engine"}}
+{"code":0,"data":{"description":"Debug resource type","name":"built_in","params":{},"provider":"emqx_rule_engine"}}
 ```
 
 
@@ -103,9 +103,9 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/
 
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources' -d \
-'{"name":"test-resource", "type": "debug_resource_type", "config": {"a":1}, "description": "test-rule"}'
+'{"name":"test-resource", "type": "built_in", "config": {"a":1}, "description": "test-rule"}'
 
-{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"debug_resource_type:test-resource","name":"test-resource","type":"debug_resource_type"}}
+{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}}
 ```
 
 ### list
@@ -113,7 +113,7 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources' -d \
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources'
 
-{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"debug_resource_type:test-resource","name":"test-resource","type":"debug_resource_type"}]}
+{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}]}
 ```
 
 
@@ -121,9 +121,9 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources'
 ### show
 
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/debug_resource_type:test-resource'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/built_in:test-resource'
 
-{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"debug_resource_type:test-resource","name":"test-resource","type":"debug_resource_type"}}
+{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}}
 ```
 
 
@@ -131,7 +131,7 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/debug
 ### delete
 
 ```shell
-$ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/debug_resource_type:test-resource'
+$ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/built_in:test-resource'
 
 {"code":0}
 ```

--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -48,9 +48,9 @@ ok
 ```shell
 $ ./bin/emqx_ctl rule-actions list
 
-action(name=default:debug_action, app=emqx_rule_engine, params=#{'$resource' => debug_resource_type}, description=Debug Action)
+action(name=built_in:inspect_action, app=emqx_rule_engine, params=#{'$resource' => built_in}, description=Debug Action)
 action(name=emqx_web_hook:forward_action, app=emqx_web_hook, params=#{'$resource' => web_hook,url => string}, description=Forward a MQTT message)
-action(name=default:republish_message, app=emqx_rule_engine, params=#{'$resource' => debug_resource_type,from => topic,to => topic}, description=Republish a MQTT message)
+action(name=built_in:republish_message, app=emqx_rule_engine, params=#{'$resource' => built_in,from => topic,to => topic}, description=Republish a MQTT message)
 ```
 
 ### show
@@ -112,14 +112,14 @@ ok
 ```shell
 $ ./bin/emqx_ctl resource-types list
 
-resource_type(name=debug_resource_type, provider=emqx_rule_engine, params=#{}, on_create={emqx_rule_actions,on_resource_create}, description=Debug resource type)
+resource_type(name=built_in, provider=emqx_rule_engine, params=#{}, on_create={emqx_rule_actions,on_resource_create}, description=Debug resource type)
 resource_type(name=web_hook, provider=emqx_web_hook, params=#{}, on_create={emqx_web_hook_actions,on_resource_create}, description=WebHook Resource)
 ```
 
 ### show
 
 ```shell
-$ ./bin/emqx_ctl resource-types show debug_resource_type
+$ ./bin/emqx_ctl resource-types show built_in
 
-resource_type(name=debug_resource_type, provider=emqx_rule_engine, params=#{}, on_create={emqx_rule_actions,on_resource_create}, description=Debug resource type)
+resource_type(name=built_in, provider=emqx_rule_engine, params=#{}, on_create={emqx_rule_actions,on_resource_create}, description=Debug resource type)
 ```

--- a/include/rule_engine.hrl
+++ b/include/rule_engine.hrl
@@ -12,13 +12,25 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 
+-define(APP, emqx_rule_engine).
+
+-type(maybe(T) :: T | undefined).
+
 -type(rule_id() :: binary()).
+-type(rule_name() :: binary()).
+
 -type(resource_id() :: binary()).
+-type(resource_name() :: binary()).
+
+-type(action_name() :: atom()).
+-type(resource_type_name() :: atom()).
+
+-type(hook() :: atom() | 'any').
 
 -record(rule,
         { id :: rule_id()
-        , name :: binary()
-        , for :: atom()
+        , name :: rule_name()
+        , for :: hook()
         , rawsql :: binary()
         , topics :: [binary()] | undefined
         , selects :: list()
@@ -29,9 +41,10 @@
         }).
 
 -record(action,
-        { name :: atom()
-        , for :: atom()
+        { name :: action_name()
+        , for :: hook()
         , app :: atom()
+        , type :: maybe(resource_name())
         , module :: module()
         , func :: atom()
         , params :: #{atom() => term()}
@@ -40,8 +53,8 @@
 
 -record(resource,
         { id :: resource_id()
-        , name :: binary()
-        , type :: atom()
+        , name :: resource_name()
+        , type :: resource_type_name()
         , config :: #{}
         , attrs :: #{}
         , description :: binary()
@@ -54,7 +67,7 @@
         }).
 
 -record(resource_type,
-        { name :: atom()
+        { name :: resource_type_name()
         , provider :: atom()
         , params :: #{}
         , on_create :: fun((map()) -> map())

--- a/src/emqx_rule_actions.erl
+++ b/src/emqx_rule_actions.erl
@@ -17,22 +17,24 @@
 
 -include_lib("emqx/include/emqx.hrl").
 
--resource_type(#{name => debug_resource_type,
+-resource_type(#{name => built_in,
                  schema => "emqx_rule_engine",
                  create => on_resource_create,
                  params => #{},
                  description => "Debug resource type"
                 }).
 
--rule_action(#{name => debug_action,
+-rule_action(#{name => inspect_action,
                for => any,
-               func => debug_action,
+               type => built_in,
+               func => inspect_action,
                params => #{},
                description => "Debug Action"
               }).
 
 -rule_action(#{name => republish_message,
                for => 'message.publish',
+               type => built_in,
                func => republish_action,
                params => #{from => topic, to => topic},
                description => "Republish a MQTT message"
@@ -44,7 +46,7 @@
 
 -export([on_resource_create/2]).
 
--export([ debug_action/1
+-export([ inspect_action/1
         , republish_action/1
         ]).
 
@@ -56,10 +58,10 @@
 on_resource_create(_Name, Conf) ->
     Conf.
 
--spec(debug_action(Params :: map()) -> action_fun()).
-debug_action(Params) ->
+-spec(inspect_action(Params :: map()) -> action_fun()).
+inspect_action(Params) ->
     fun(Data) ->
-        io:format("Action input data: ~p~nAction init params: ~p~n", [Data, Params])
+        io:format("[Inspect Action]~nAction input data: ~p~nAction init params: ~p~n", [Data, Params])
     end.
 
 %% A Demo Action.

--- a/src/emqx_rule_engine.erl
+++ b/src/emqx_rule_engine.erl
@@ -63,6 +63,7 @@ find_resource_types(App) ->
 
 new_action({App, Mod, #{name := Name,
                         for := Hook,
+                        type := Type,
                         func := Func,
                         params := Params,
                         description := Descr}}) ->
@@ -71,12 +72,7 @@ new_action({App, Mod, #{name := Name,
         true -> ok;
         false -> error({action_func_not_found, Func})
     end,
-    Prefix = case App =:= ?MODULE of
-                 true -> default;
-                 false -> App
-             end,
-    Name1 = list_to_atom(lists:concat([Prefix, ":", Name])),
-    #action{name = Name1, for = Hook, app = App,
+    #action{name = action_name(Type, Name), for = Hook, app = App, type = Type,
             module = Mod, func = Func, params = Params,
             description = iolist_to_binary(Descr)}.
 
@@ -153,9 +149,6 @@ create_rule(Params = #{name := Name,
         Error -> error(Error)
     end.
 
-rule_id(Name) ->
-    iolist_to_binary([Name, ":", integer_to_list(erlang:system_time())]).
-
 prepare_action(Name) when is_atom(Name) ->
     prepare_action({Name, #{}});
 prepare_action({Name, Args}) ->
@@ -198,3 +191,8 @@ create_resource(#{name := Name,
             {error, {resource_type_not_found, Name}}
     end.
 
+rule_id(Name) ->
+    iolist_to_binary([Name, ":", integer_to_list(erlang:system_time())]).
+
+action_name(Type, Name) ->
+    list_to_atom(lists:concat([Type, ":", Name])).

--- a/src/emqx_rule_engine_api.erl
+++ b/src/emqx_rule_engine_api.erl
@@ -102,11 +102,18 @@
             descr  => "Show a resource type"
            }).
 
--rest_api(#{name   => list_resources_of_type,
+-rest_api(#{name   => list_resources_by_type,
             method => 'GET',
             path   => "/resource_types/:atom:type/resources",
-            func   => list_resources_of_type,
+            func   => list_resources_by_type,
             descr  => "List all resources of a resource type"
+           }).
+
+-rest_api(#{name   => list_actions_by_type,
+            method => 'GET',
+            path   => "/resource_types/:atom:type/actions",
+            func   => list_actions_by_type,
+            descr  => "List all actions of a resource type"
            }).
 
 -export([ create_rule/2
@@ -126,7 +133,8 @@
         ]).
 
 -export([ list_resource_types/2
-        , list_resources_of_type/2
+        , list_resources_by_type/2
+        , list_actions_by_type/2
         , show_resource_type/2
         ]).
 
@@ -195,8 +203,11 @@ create_resource(#{}, Params) ->
 list_resources(#{}, _Params) ->
     return_all(emqx_rule_registry:get_resources()).
 
-list_resources_of_type(#{type := Type}, _Params) ->
-    return_all(emqx_rule_registry:get_resources_of_type(Type)).
+list_resources_by_type(#{type := Type}, _Params) ->
+    return_all(emqx_rule_registry:get_resources_by_type(Type)).
+
+list_actions_by_type(#{type := Type}, _Params) ->
+    return_all(emqx_rule_registry:get_actions_by_type(Type)).
 
 show_resource(#{id := Id}, _Params) ->
     reply_with(fun emqx_rule_registry:find_resource/1, Id).
@@ -247,10 +258,12 @@ record_to_map(#rule{id = Id,
 
 record_to_map(#action{name = Name,
                       app = App,
+                      type = Type,
                       params = Params,
                       description = Descr}) ->
     #{name => Name,
       app => App,
+      type => Type,
       params => Params,
       description => Descr
      };


### PR DESCRIPTION
Add `resource type` in the action's attrs. An action must belong to a resource type, but it may not need a resource id in the action-params when initializing the action.

e.g. 

Assume there is an action named 'mysql:inspect_action' just for printing mysql-related action/resource params. The inspect_action is designed for mysql resource type, but it need not a mysql connection as it won't write/read anything from the database.

The action name is changed to `Type:ActionName` 