### PR TITLE
Improve the input data for actions

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -54,7 +54,7 @@ $ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/
 ```shell
 $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/actions
 
-{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{"$resource":"built_in"}},{"app":"emqx_rule_engine","description":"Republish a MQTT message","name":"built_in:republish_message","params":{"$resource":"built_in","from":"topic","to":"topic"}}]}
+{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{"$resource":"built_in"}},{"app":"emqx_rule_engine","description":"Republish a MQTT message","name":"built_in:republish_action","params":{"$resource":"built_in","from":"topic","to":"topic"}}]}
 ```
 
 

--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -50,7 +50,7 @@ $ ./bin/emqx_ctl rule-actions list
 
 action(name=built_in:inspect_action, app=emqx_rule_engine, params=#{'$resource' => built_in}, description=Debug Action)
 action(name=emqx_web_hook:forward_action, app=emqx_web_hook, params=#{'$resource' => web_hook,url => string}, description=Forward a MQTT message)
-action(name=built_in:republish_message, app=emqx_rule_engine, params=#{'$resource' => built_in,from => topic,to => topic}, description=Republish a MQTT message)
+action(name=built_in:republish_action, app=emqx_rule_engine, params=#{'$resource' => built_in,from => topic,to => topic}, description=Republish a MQTT message)
 ```
 
 ### show

--- a/src/emqx_rule_runtime.erl
+++ b/src/emqx_rule_runtime.erl
@@ -139,9 +139,9 @@ apply_rules([Rule = #rule{name = Name, topics = Filters}|More], Input) ->
 apply_rule(#rule{selects = Selects,
                  conditions = Conditions,
                  actions = Actions}, Input) ->
-    Output = select_and_transform(Selects, Input),
-    match_conditions(Conditions, Output)
-        andalso take_actions(Actions, Output).
+    Selected = select_and_transform(Selects, Input),
+    match_conditions(Conditions, Selected)
+        andalso take_actions(Actions, Selected, Input).
 
 %% Step1 -> Match topic with filters
 match_topic(_Topic, []) ->
@@ -200,11 +200,11 @@ match_conditions({}, _Data) ->
     true.
 
 %% Step4 -> Take actions
-take_actions(Actions, Data) ->
-    lists:foreach(fun(Action) -> take_action(Action, Data) end, Actions).
+take_actions(Actions, Selected, Envs) ->
+    lists:foreach(fun(Action) -> take_action(Action, Selected, Envs) end, Actions).
 
-take_action(#{apply := Apply}, Data) ->
-    Apply(Data).
+take_action(#{apply := Apply}, Selected, Envs) ->
+    Apply(Selected, Envs).
 
 eval({var, Var}, Input) -> %% nested
     nested_get(Var, Input);


### PR DESCRIPTION
Now the actions accept 2 args, the `selected data` and the `envs`:

```erlang
-type(action_fun() :: fun((SelectedData::map(), Envs::map()) -> Result::any())).

-spec(inspect_action(Params :: map()) -> action_fun()).
inspect_action(Params) ->
    fun(Selected, Envs) ->
        io:format("[built_in:inspect_action]~n"
                  "\tSelected Data: ~p~n"
                  "\tEnvs: ~p~n"
                  "\tAction Init Params: ~p~n", [Selected, Envs, Params])
    end.
```

The selected data is the fields by applying the SQL SELECT onto the message/event.
The Env is the environment params including all fields of the original message event.