### PR TITLE
Re-design Names and IDs

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -179,7 +179,7 @@ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules' -d \
 Start a `web server` using `nc`, and then connect to emqx broker using a mqtt client with username = 'Shawn':
 
 ```shell
-nc -l 127.0.0.1 9910
+echo -e "HTTP/1.1 200 OK\n\n $(date)" | nc -l 127.0.0.1 9910
 
 POST / HTTP/1.1
 content-type: application/json

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -1,32 +1,30 @@
 #Rule-Engine-APIs
 
-
-
 ## ENVs
 
-APPSECRET="5bce2ce904d5f8:Mjg2ODA3NTU0MjAzNTAzMTU1ODI3MzE5Mzg3MTU3Mjk5MjA"
+APPSECRET="37990d56454af8:Mjg3Mjg4NDM0NDQ0MjkzNDU5NzQ4NDM4OTc3MjAwMTI4MDA"
 
 ## Rules
 
 ### create
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules' -d \
-'{"name":"test-rule","for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"built_in:inspect_action","params":{"a":1}}],"description":"test-rule"}'
+'{"for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"inspect","params":{"a":1}}],"description":"test-rule"}'
 
-{"code":0,"data":{"actions":[{"name":"built_in:inspect_action","params":{"a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120126626615666","name":"test-rule","rawsql":"select * from \"t/a\""}}
+{"code":0,"data":{"actions":[{"name":"inspect","params":{"a":1}}],"description":"test-rule","enabled":true,"for":"message.publish","id":"rule:6afb617f","rawsql":"select * from \"t/a\""}}
 
 ## with a resource id in the action args
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules' -d \
-'{"name":"test-rule","for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource"}}],"description":"test-rule"}'
+'{"for":"message.publish","rawsql":"select * from \"t/a\"","actions":[{"name":"inspect","params":{"$resource":"resource:71df3086"}}],"description":"test-rule"}'
 
-{"code":0,"data":{"actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}}
+{"code":0,"data":{"actions":[{"name":"inspect","params":{"$resource":"resource:71df3086","a":1}}],"description":"test-rule","enabled":true,"for":"message.publish","id":"rule:a5f4cee1","rawsql":"select * from \"t/a\""}}
 ```
 
 ### show
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/test-rule:1555120233443199609'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/rule:6afb617f'
 
-{"code":0,"data":{"actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}}
+{"code":0,"data":{"actions":[{"name":"inspect","params":{"a":1}}],"description":"test-rule","enabled":true,"for":"message.publish","id":"rule:6afb617f","rawsql":"select * from \"t/a\""}}
 ```
 
 ### list
@@ -34,18 +32,16 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/test-rule
 ```shell
 $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/rules
 
-{"code":0,"data":[{"actions":[{"name":"built_in:inspect_action","params":{"a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120126626615666","name":"test-rule","rawsql":"select * from \"t/a\""},{"actions":[{"name":"built_in:inspect_action","params":{"$resource":"built_in:test-resource","a":1}}],"description":"test-rule","enabled":true,"id":"test-rule:1555120233443199609","name":"test-rule","rawsql":"select * from \"t/a\""}]}
+{"code":0,"data":[{"actions":[{"name":"inspect","params":{"a":1}}],"description":"test-rule","enabled":true,"for":"message.publish","id":"rule:6afb617f","rawsql":"select * from \"t/a\""}]}
 ```
 
 ### delete
 
 ```shell
-$ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/test-rule:1555120233443199609'
+$ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/rule:6afb617f'
 
 {"code":0}
 ```
-
-
 
 ## Actions
 
@@ -54,7 +50,7 @@ $ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules/
 ```shell
 $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/actions
 
-{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{"$resource":"built_in"}},{"app":"emqx_rule_engine","description":"Republish a MQTT message","name":"built_in:republish_action","params":{"$resource":"built_in","target_topic":"topic"}}]}
+{"code":0,"data":[{"app":"emqx_rule_engine","description":"Republish a MQTT message to a another topic","for":"message.publish","name":"republish","params":{...},"type":"built_in"},{"app":"emqx_rule_engine","description":"Inspect the details of action params for debug purpose","for":"$any","name":"inspect","params":{},"type":"built_in"},{"app":"emqx_web_hook","description":"Forward Messages to Web Server","for":"message.publish","name":"data_to_webserver","params":{...},"type":"web_hook"}]}
 ```
 
 ### list all actions of a resource type
@@ -62,10 +58,8 @@ $ curl -v --basic -u $APPSECRET -k http://localhost:8080/api/v3/actions
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/built_in/actions'
 
-{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{},"type":"built_in"},{"app":"emqx_rule_engine","description":"Republish a MQTT message","name":"built_in:republish_action","params":{"target_topic":"topic"},"type":"built_in"}]}
+{"code":0,"data":[{"app":"emqx_rule_engine","description":"Inspect the details of action params for debug purpose","for":"$any","name":"inspect","params":{},"type":"built_in"},{"app":"emqx_rule_engine","description":"Republish a MQTT message to a another topic","for":"message.publish","name":"republish","params":{...},"type":"built_in"}]}
 ```
-
-
 
 ### list all actions of a hook type
 
@@ -76,26 +70,22 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions?for=mes
 
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions?for=$messages'
 
-{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","for":"$any","name":"built_in:inspect_action","params":{},"type":"built_in"},{"app":"emqx_rule_engine","description":"Republish a MQTT message","for":"message.publish","name":"built_in:republish_action","params":{"target_topic":"topic"},"type":"built_in"},{"app":"emqx_web_hook","description":"Forward Messages to Web Server","for":"message.publish","name":"web_hook:publish_action","params":{"$resource":"web_hook"},"type":"web_hook"}]}
+{"code":0,"data":[{"app":"emqx_rule_engine","description":"Debug Action","for":"$any","name":"inspect","params":{},"type":"built_in"},{"app":"emqx_rule_engine","description":"Republish a MQTT message","for":"message.publish","name":"built_in:republish_action","params":{"target_topic":"topic"},"type":"built_in"},{"app":"emqx_web_hook","description":"Forward Messages to Web Server","for":"message.publish","name":"web_hook:publish_action","params":{"$resource":"web_hook"},"type":"web_hook"}]}
 
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions?for=$events'
 
-{"code":0,"data":[{"app":"emqx_web_hook","description":"Forward Events to Web Server","for":"$events","name":"web_hook:event_action","params":{"$resource":"web_hook","template":"json"},"type":"web_hook"},{"app":"emqx_rule_engine","description":"Debug Action","for":"$any","name":"built_in:inspect_action","params":{},"type":"built_in"}]}
+{"code":0,"data":[{"app":"emqx_web_hook","description":"Forward Events to Web Server","for":"$events","name":"web_hook:event_action","params":{"$resource":"web_hook","template":"json"},"type":"web_hook"},{"app":"emqx_rule_engine","description":"Debug Action","for":"$any","name":"inspect","params":{},"type":"built_in"}]}
 
 
 ```
-
-
 
 ### show
 
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions/built_in:inspect_action'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/actions/inspect'
 
-{"code":0,"data":{"app":"emqx_rule_engine","description":"Debug Action","name":"built_in:inspect_action","params":{"$resource":"built_in"}}}
+{"code":0,"data":{"app":"emqx_rule_engine","description":"Debug Action","name":"inspect","params":{"$resource":"built_in"}}}
 ```
-
-
 
 ## Resource Types
 
@@ -112,7 +102,7 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types'
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/built_in/resources'
 
-{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}]}
+{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"resource:71df3086","type":"built_in"}]}
 ```
 
 ### show
@@ -131,9 +121,9 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_types/
 
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources' -d \
-'{"name":"test-resource", "type": "built_in", "config": {"a":1}, "description": "test-resource"}'
+'{"type": "built_in", "config": {"a":1}, "description": "test-resource"}'
 
-{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}}
+{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-resource","id":"resource:71df3086","type":"built_in"}}
 ```
 
 ### list
@@ -141,25 +131,21 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources' -d \
 ```shell
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources'
 
-{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}]}
+{"code":0,"data":[{"attrs":"undefined","config":{"a":1},"description":"test-resource","id":"resource:71df3086","type":"built_in"}]}
 ```
-
-
 
 ### show
 
 ```shell
-$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/built_in:test-resource'
+$ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/resource:71df3086'
 
-{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-rule","id":"built_in:test-resource","name":"test-resource","type":"built_in"}}
+{"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-resource","id":"resource:71df3086","type":"built_in"}}
 ```
-
-
 
 ### delete
 
 ```shell
-$ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/built_in:test-resource'
+$ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/resource:71df3086'
 
 {"code":0}
 ```
@@ -169,26 +155,28 @@ $ curl -XDELETE -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resour
 ``` shell
 
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources' -d \
-'{"name":"webhook1", "type": "web_hook", "config": {"url": "http://127.0.0.1:9910", "headers": {"token":"axfw34y235wrq234t4ersgw4t"}, "method": "POST"}, "description": "web hook resource-1"}'
+'{"type": "web_hook", "config": {"url": "http://127.0.0.1:9910", "headers": {"token":"axfw34y235wrq234t4ersgw4t"}, "method": "POST"}, "description": "web hook resource-1"}'
+
+{"code":0,"data":{"attrs":"undefined","config":{"headers":{"token":"axfw34y235wrq234t4ersgw4t"},"method":"POST","url":"http://127.0.0.1:9910"},"description":"web hook resource-1","id":"resource:8531a11f","type":"web_hook"}}
 
 curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/rules' -d \
-'{"name":"connected_msg_to_http","for":"client.connected","rawsql":"select * from \"#\"","actions":[{"name":"web_hook:event_action","params":{"$resource": "web_hook:webhook1", "template": {"client": "${client_id}", "user": "${username}", "c": {"u": "${username}", "e": "${e}"}}}}],"description":"Forward connected events to webhook"}'
+'{"for":"client.connected","rawsql":"SELECT client_id as c, username as u.name FROM \"#\"","actions":[{"name":"data_to_webserver","params":{"$resource": "resource:8531a11f"}}],"description":"Forward connected events to webhook"}'
 
+{"code":0,"data":{"actions":[{"name":"data_to_webserver","params":{"$resource":"resource:8531a11f","headers":{"token":"axfw34y235wrq234t4ersgw4t"},"method":"POST","url":"http://127.0.0.1:9910"}}],"description":"Forward connected events to webhook","enabled":true,"for":"client.connected","id":"rule:4fe05936","rawsql":"select * from \"#\""}}
 ```
 
 Start a `web server` using `nc`, and then connect to emqx broker using a mqtt client with username = 'Shawn':
 
 ```shell
-echo -e "HTTP/1.1 200 OK\n\n $(date)" | nc -l 127.0.0.1 9910
+$ echo -e "HTTP/1.1 200 OK\n\n $(date)" | nc -l 127.0.0.1 9910
 
 POST / HTTP/1.1
 content-type: application/json
-content-length: 80
+content-length: 48
 te:
 host: 127.0.0.1:9910
 connection: keep-alive
 token: axfw34y235wrq234t4ersgw4t
 
-{"client":"clientId-E7EYzGa6HK","user":"Shawn","c":{"u":"Shawn","e":null}}
-
+{"c":"clientId-bP70ymeIyo","u":{"name":"Shawn"}
 ```

--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -5,17 +5,17 @@
 ### create
 
 ```shell
-  $ ./bin/emqx_ctl rules create 'steven_msg_to_http' 'message.publish' 'SELECT payload FROM "#" where user=Steven' '[{"name":"web_hook:publish_action", "params": {"$resource": "web_hook:webhook1"}}]' -d "Forward msgs from clientid=Steven to webhook"
+  $ ./bin/emqx_ctl rules create 'message.publish' 'SELECT payload FROM "#" where user=Steven' '[{"name":"data_to_webserver", "params": {"$resource": "resource:19addfef"}}]' --descr "Msg From Steven to WebServer"
 
-Rule steven_msg_to_http:1555138068602953000 created
+Rule rule:72456057 created
 ```
 
 ### show
 
 ```shell
-$ ./bin/emqx_ctl rules show steven_msg_to_http:1555138068602953000
+$ ./bin/emqx_ctl rules show rule:72456057
 
-rule(id=steven_msg_to_http:1555138068602953000, name=steven_msg_to_http, for=message.publish, rawsql=SELECT payload FROM "#" where user=Steven, actions=<<"[{\"name\":\"web_hook:publish_action\",\"params\":{\"$resource\":\"web_hook:webhook1\",\"url\":\"http://www.baidu.com\"}}]">>, enabled=true, description=Forward msgs from clientid=Steven to webhook)
+rule(id='rule:72456057', for='message.publish', rawsql='SELECT payload FROM "#" where user=Steven', actions=[{"name":"data_to_webserver","params":{"$resource":"resource:19addfef","url":"http://host-name/chats"}}], enabled='true', description='Msg From Steven to WebServer')
 ```
 
 ### list
@@ -23,14 +23,14 @@ rule(id=steven_msg_to_http:1555138068602953000, name=steven_msg_to_http, for=mes
 ```shell
 $ ./bin/emqx_ctl rules list
 
-rule(id=steven_msg_to_http:1555138068602953000, name=steven_msg_to_http, for=message.publish, rawsql=SELECT payload FROM "#" where user=Steven, actions=<<"[{\"name\":\"web_hook:publish_action\",\"params\":{\"$resource\":\"web_hook:webhook1\",\"url\":\"http://www.baidu.com\"}}]">>, enabled=true, description=Forward msgs from clientid=Steven to webhook)
+rule(id='rule:72456057', for='message.publish', rawsql='SELECT payload FROM "#" where user=Steven', actions=[{"name":"data_to_webserver","params":{"$resource":"resource:19addfef","url":"http://host-name/chats"}}], enabled='true', description='Msg From Steven to WebServer')
 
 ```
 
 ### delete
 
 ```shell
-$ ./bin/emqx_ctl rules delete 'steven_msg_to_http:1555138068602953000'
+$ ./bin/emqx_ctl rules delete 'rule:72456057'
 
 ok
 ```
@@ -42,16 +42,17 @@ ok
 ```shell
 $ ./bin/emqx_ctl rule-actions list
 
-action(name=built_in:inspect_action, app=emqx_rule_engine, params=#{'$resource' => built_in}, description=Debug Action)
-action(name=web_hook:publish_action, app=emqx_web_hook, params=#{'$resource' => web_hook,url => string}, description=Forward a MQTT message)
+action(name='republish', app='emqx_rule_engine', for='message.publish', type='built_in', params=#{...}, description='Republish a MQTT message to a another topic')
+action(name='inspect', app='emqx_rule_engine', for='$any', type='built_in', params=#{...}, description='Inspect the details of action params for debug purpose')
+action(name='data_to_webserver', app='emqx_web_hook', for='message.publish', type='web_hook', params=#{...}, description='Forward Messages to Web Server')
 ```
 
 ### show
 
 ```shell
-$ ./bin/emqx_ctl rule-actions show 'web_hook:publish_action'
+$ ./bin/emqx_ctl rule-actions show 'data_to_webserver'
 
-action(name=web_hook:publish_action, app=emqx_web_hook, params=#{'$resource' => web_hook,url => string}, description=Forward a MQTT message)
+action(name='data_to_webserver', app='emqx_web_hook', for='message.publish', type='web_hook', params=#{...}, description='Forward Messages to Web Server')
 ```
 
 ## Resource
@@ -59,9 +60,9 @@ action(name=web_hook:publish_action, app=emqx_web_hook, params=#{'$resource' => 
 ### create
 
 ```shell
-$ ./bin/emqx_ctl resources create 'webhook1' 'web_hook' -c '{"url": "http://host-name/chats"}'
+$ ./bin/emqx_ctl resources create 'web_hook' -c '{"url": "http://host-name/chats"}' --descr 'Resource towards http://host-name/chats'
 
-Resource web_hook:webhook1 created
+Resource resource:19addfef created
 ```
 
 ### list
@@ -69,7 +70,7 @@ Resource web_hook:webhook1 created
 ```shell
 $ ./bin/emqx_ctl resources list
 
-resource(id=web_hook:webhook1, name=webhook1, type=web_hook, config=#{}, attrs=undefined, description=)
+resource(id='resource:19addfef', type='web_hook', config=#{<<"url">> => <<"http://host-name/chats">>}, attrs=undefined, description='Resource towards http://host-name/chats')
 
 ```
 
@@ -78,22 +79,21 @@ resource(id=web_hook:webhook1, name=webhook1, type=web_hook, config=#{}, attrs=u
 ```shell
 $ ./bin/emqx_ctl resources list -t 'web_hook'
 
-resource(id=web_hook:webhook1, name=webhook1, type=web_hook, config=#{}, attrs=undefined, description=)
-
+resource(id='resource:19addfef', type='web_hook', config=#{<<"url">> => <<"http://host-name/chats">>}, attrs=undefined, description='Resource towards http://host-name/chats')
 ```
 
 ### show
 
 ```shell
-$ ./bin/emqx_ctl resources show 'web_hook:webhook1'
+$ ./bin/emqx_ctl resources show 'resource:19addfef'
 
-resource(id=web_hook:webhook1, name=webhook1, type=web_hook, config=#{}, attrs=undefined, description=)
+resource(id='resource:19addfef', type='web_hook', config=#{<<"url">> => <<"http://host-name/chats">>}, attrs=undefined, description='Resource towards http://host-name/chats')
 ```
 
 ### delete
 
 ```shell
-$ ./bin/emqx_ctl resources delete 'web_hook:webhook1'
+$ ./bin/emqx_ctl resources delete 'resource:19addfef'
 
 ok
 ```
@@ -105,8 +105,8 @@ ok
 ```shell
 $ ./bin/emqx_ctl resource-types list
 
-resource_type(name=built_in, provider=emqx_rule_engine, params=#{}, on_create={emqx_rule_actions,on_resource_create}, description=Debug resource type)
-resource_type(name=web_hook, provider=emqx_web_hook, params=#{}, on_create={emqx_web_hook_actions,on_resource_create}, description=WebHook Resource)
+resource_type(name='built_in', provider='emqx_rule_engine', params=#{...}, on_create={emqx_rule_actions,on_resource_create}, description='The built in resource type for debug purpose')
+resource_type(name='web_hook', provider='emqx_web_hook', params=#{...}, on_create={emqx_web_hook_actions,on_resource_create}, description='WebHook Resource')
 ```
 
 ### show
@@ -114,32 +114,33 @@ resource_type(name=web_hook, provider=emqx_web_hook, params=#{}, on_create={emqx
 ```shell
 $ ./bin/emqx_ctl resource-types show built_in
 
-resource_type(name=built_in, provider=emqx_rule_engine, params=#{}, on_create={emqx_rule_actions,on_resource_create}, description=Debug resource type)
+resource_type(name='built_in', provider='emqx_rule_engine', params=#{}, description='The built in resource type for debug purpose')
 ```
 
 ## Rule example using webhook
 
 ``` shell
+1. Create a webhook resource to URL http://127.0.0.1:9910.
+./bin/emqx_ctl resources create 'web_hook' --config '{"url": "http://127.0.0.1:9910", "headers": {"token":"axfw34y235wrq234t4ersgw4t"}, "method": "POST"}'
+Resource resource:3128243e created
 
-./bin/emqx_ctl resources create 'webhook1' 'web_hook' -c '{"url": "http://127.0.0.1:9910", "headers": {"token":"axfw34y235wrq234t4ersgw4t"}, "method": "POST"}'
-
-./bin/emqx_ctl rules create 'connected_msg_to_http' 'client.connected' 'SELECT * FROM "#"' '[{"name":"web_hook:event_action", "params": {"$resource": "web_hook:webhook1", "template": {"client": "${client_id}", "user": "${username}", "c": {"u": "${username}", "e": "${e}"}}}}]' -d "Forward connected events to webhook"
-
+2. Create a rule using action data_to_webserver, and bind above resource to that action.
+./bin/emqx_ctl rules create 'client.connected' 'SELECT client_id as c, username as u.name FROM "#"' '[{"name":"data_to_webserver", "params": {"$resource": "resource:3128243e"}}]' --descr "Forward Connected Events to WebServer"
+Rule rule:222b59f7 created
 ```
 
-Start a `web server` using `nc`, and then connect to emqx broker using a mqtt client with username = 'Shawn':
+Start a simple `Web Server` using `nc`, and then connect to emqx broker using a mqtt client with username = 'Shawn':
 
 ```shell
-nc -l 127.0.0.1 9910
+$ echo -e "HTTP/1.1 200 OK\n\n $(date)" | nc -l 127.0.0.1 9910
 
 POST / HTTP/1.1
 content-type: application/json
-content-length: 80
+content-length: 48
 te:
 host: 127.0.0.1:9910
 connection: keep-alive
 token: axfw34y235wrq234t4ersgw4t
 
-{"client":"clientId-E7EYzGa6HK","user":"Shawn","c":{"u":"Shawn","e":null}}
-
+{"c":"clientId-bP70ymeIyo","u":{"name":"Shawn"}
 ```

--- a/include/rule_engine.hrl
+++ b/include/rule_engine.hrl
@@ -29,7 +29,6 @@
 
 -record(rule,
         { id :: rule_id()
-        , name :: rule_name()
         , for :: hook()
         , rawsql :: binary()
         , topics :: [binary()] | undefined
@@ -53,7 +52,6 @@
 
 -record(resource,
         { id :: resource_id()
-        , name :: resource_name()
         , type :: resource_type_name()
         , config :: #{}
         , attrs :: #{}

--- a/src/emqx_rule_actions.erl
+++ b/src/emqx_rule_actions.erl
@@ -35,19 +35,19 @@
                  description => "The built in resource type for debug purpose"
                 }).
 
--rule_action(#{name => inspect_action,
+-rule_action(#{name => inspect,
                for => '$any',
                type => built_in,
-               func => inspect_action,
+               func => inspect,
                params => #{},
                title => <<"Inspect Action">>,
                description => <<"Inspect the details of action params for debug purpose">>
               }).
 
--rule_action(#{name => republish_action,
+-rule_action(#{name => republish,
                for => 'message.publish',
                type => built_in,
-               func => republish_action,
+               func => republish,
                params => ?REPUBLISH_PARAMS_SPEC,
                title => <<"Republish Action">>,
                description => "Republish a MQTT message to a another topic"
@@ -59,8 +59,8 @@
 
 -export([on_resource_create/2]).
 
--export([ inspect_action/1
-        , republish_action/1
+-export([ inspect/1
+        , republish/1
         ]).
 
 %%------------------------------------------------------------------------------
@@ -71,22 +71,22 @@
 on_resource_create(_Name, Conf) ->
     Conf.
 
--spec(inspect_action(Params :: map()) -> action_fun()).
-inspect_action(Params) ->
+-spec(inspect(Params :: map()) -> action_fun()).
+inspect(Params) ->
     fun(Selected, Envs) ->
-        io:format("[built_in:inspect_action]~n"
+        io:format("[inspect]~n"
                   "\tSelected Data: ~p~n"
                   "\tEnvs: ~p~n"
                   "\tAction Init Params: ~p~n", [Selected, Envs, Params])
     end.
 
 %% A Demo Action.
--spec(republish_action(#{binary() := emqx_topic:topic()})
+-spec(republish(#{binary() := emqx_topic:topic()})
       -> action_fun()).
-republish_action(#{<<"target_topic">> := TargetTopic}) ->
+republish(#{<<"target_topic">> := TargetTopic}) ->
     fun(Selected, #{qos := QoS, from := Client,
                     flags := Flags, headers := Headers}) ->
-        ?LOG(debug, "[built_in:republish_action] republish to: ~p, Payload: ~p",
+        ?LOG(debug, "[republish] republish to: ~p, Payload: ~p",
                         [TargetTopic, Selected]),
         emqx_broker:safe_publish(
             #message{
@@ -102,7 +102,7 @@ republish_action(#{<<"target_topic">> := TargetTopic}) ->
     end.
 
 republish_from(Client) ->
-    C = bin(Client), <<"built_in:republish_action:", C/binary>>.
+    C = bin(Client), <<"built_in:republish:", C/binary>>.
 
 bin(Bin) when is_binary(Bin) -> Bin;
 bin(Atom) when is_atom(Atom) ->

--- a/src/emqx_rule_engine_api.erl
+++ b/src/emqx_rule_engine_api.erl
@@ -262,14 +262,12 @@ reply_with(Find, Key) ->
     end.
 
 record_to_map(#rule{id = Id,
-                    name = Name,
                     for = Hook,
                     rawsql = RawSQL,
                     actions = Actions,
                     enabled = Enabled,
                     description = Descr}) ->
     #{id => Id,
-      name => Name,
       for => Hook,
       rawsql => RawSQL,
       actions => [maps:remove(apply, Act) || Act <- Actions],
@@ -292,13 +290,11 @@ record_to_map(#action{name = Name,
      };
 
 record_to_map(#resource{id = Id,
-                        name = Name,
                         type = Type,
                         config = Config,
                         attrs = Attrs,
                         description = Descr}) ->
     #{id => Id,
-      name => Name,
       type => Type,
       config => Config,
       attrs => Attrs,
@@ -319,8 +315,6 @@ parse_rule_params(Params) ->
     parse_rule_params(Params, #{description => <<"">>}).
 parse_rule_params([], Rule) ->
     Rule;
-parse_rule_params([{<<"name">>, Name} | Params], Rule) ->
-    parse_rule_params(Params, Rule#{name => Name});
 parse_rule_params([{<<"for">>, Hook} | Params], Rule) ->
     parse_rule_params(Params, Rule#{for => ?RAISE(binary_to_existing_atom(Hook,utf8), {invalid_hook,Hook})});
 parse_rule_params([{<<"rawsql">>, RawSQL} | Params], Rule) ->
@@ -345,8 +339,6 @@ parse_resource_params(Params) ->
     parse_resource_params(Params, #{config => #{}, description => <<"">>}).
 parse_resource_params([], Res) ->
     Res;
-parse_resource_params([{<<"name">>, Name} | Params], Res) ->
-    parse_resource_params(Params, Res#{name => Name});
 parse_resource_params([{<<"type">>, ResourceType} | Params], Res) ->
     try parse_resource_params(Params, Res#{type => binary_to_existing_atom(ResourceType, utf8)})
     catch error:badarg ->

--- a/src/emqx_rule_id.erl
+++ b/src/emqx_rule_id.erl
@@ -1,0 +1,55 @@
+%% Copyright (c) 2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(emqx_rule_id).
+
+-export([gen/0, gen/1]).
+
+-define(SHORT, 8).
+
+%%------------------------------------------------------------------------------
+%% APIs
+%%------------------------------------------------------------------------------
+-spec(gen() -> list()).
+gen() ->
+    gen(?SHORT).
+
+-spec(gen(integer()) -> list()).
+gen(Len) ->
+    BitLen = Len * 4,
+    <<R:BitLen>> = crypto:strong_rand_bytes(Len div 2),
+    int_to_hex(R, Len).
+
+%%------------------------------------------------------------------------------
+%% Internal Functions
+%%------------------------------------------------------------------------------
+
+int_to_hex(I, N) when is_integer(I), I >= 0 ->
+    int_to_hex([], I, 1, N).
+
+int_to_hex(L, I, Count, N)
+    when I < 16 ->
+    pad([int_to_hex(I) | L], N - Count);
+int_to_hex(L, I, Count, N) ->
+    int_to_hex([int_to_hex(I rem 16) | L], I div 16, Count + 1, N).
+
+int_to_hex(I) when 0 =< I, I =< 9 ->
+    I + $0;
+int_to_hex(I) when 10 =< I, I =< 15 ->
+    (I - 10) + $a.
+
+pad(L, 0) ->
+    L;
+pad(L, Count) ->
+    pad([$0 | L], Count - 1).

--- a/src/emqx_rule_registry.erl
+++ b/src/emqx_rule_registry.erl
@@ -302,13 +302,13 @@ remove_resource(ResId) when is_binary(ResId) ->
 %% @private
 delete_resource(ResId) ->
     try
-        [[?RAISE(not_found = find_resource(ResId1), {exists, Name})
+        [[?RAISE(not_found = find_resource(ResId1), {exists, Id})
             || #{params := #{<<"$resource">> := ResId1}} <- Actions]
-                || #rule{name = Name, actions = Actions} <- get_rules()],
+                || #rule{id = Id, actions = Actions} <- get_rules()],
         mnesia:delete(?RES_TAB, ResId, write)
     catch
-        throw:{exists, Name} ->
-            throw({dependency_exists, {rule_name, Name}})
+        throw:{exists, Id} ->
+            throw({dependency_exists, {rule, Id}})
     end.
 
 %% @private

--- a/src/emqx_rule_runtime.erl
+++ b/src/emqx_rule_runtime.erl
@@ -125,22 +125,22 @@ apply_rules([], _Input) ->
     ok;
 apply_rules([#rule{enabled = false}|More], Input) ->
     apply_rules(More, Input);
-apply_rules([Rule = #rule{name = Name, for = 'message.publish', topics = Filters}|More], Input) ->
+apply_rules([Rule = #rule{id = RuleID, for = 'message.publish', topics = Filters}|More], Input) ->
     Topic = get_value(topic, Input),
     try match_topic(Topic, Filters)
         andalso apply_rule(Rule, Input)
     catch
         _:Error:StkTrace ->
             ?LOG(error, "Apply message.publish rule ~s error: ~p. Statcktrace:~n~p",
-                 [Name, Error, StkTrace])
+                 [RuleID, Error, StkTrace])
     end,
     apply_rules(More, Input);
-apply_rules([Rule = #rule{name = Name}|More], Input) ->
+apply_rules([Rule = #rule{id = RuleID}|More], Input) ->
     try apply_rule(Rule, Input)
     catch
         _:Error:StkTrace ->
             ?LOG(error, "Apply rule ~s error: ~p. Statcktrace:~n~p",
-                 [Name, Error, StkTrace])
+                 [RuleID, Error, StkTrace])
     end,
     apply_rules(More, Input).
 


### PR DESCRIPTION
At present we have both names and ids for resources and rules. Names are mainly for short descriptions and ids are for identifiers.
When creating a rule or resource, the user provides a name, and then rule-engine returns a server-side-generated id.

If a user run `emqx_ctl rules create <name> <config>` multiple times using the same name, multiple rules (with different ids) would be created by the rule-engine. This may confuse users, as they would expect that names can be used as identifers.

The problem is, `name` is not actually needed, it is only a word describing what the rule is for. We have a `descr` field for that. Users should create a rule by `emqx_ctl rules create <config>` and get an id, that's it.

The changes in this PR:

- Remove the field `name` from resources and rules.
  As explained above, we only need IDs.
- Change format of action-name from `<resource_type>:<name>` to `<name>`.
  Don't add a prefix on action names, use exactly the one defined by resource providers.
  We already have a `type` field for actions.
- Change format of rule-id from `<rule-name>:<timestamp>` to `rule:<random_string>`.
  e.g. rule:3bc859b2.