### PR TITLE
Re-start resources manually

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -124,6 +124,14 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources' -d \
 {"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-resource","id":"resource:71df3086","type":"built_in"}}
 ```
 
+### start
+
+```shell
+$ curl -XPOST -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/resource:71df3086'
+
+{"code":0}
+```
+
 ### list
 
 ```shell
@@ -138,6 +146,14 @@ $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources'
 $ curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resources/resource:71df3086'
 
 {"code":0,"data":{"attrs":"undefined","config":{"a":1},"description":"test-resource","id":"resource:71df3086","type":"built_in"}}
+```
+
+### get resource status
+
+```shell
+curl -v --basic -u $APPSECRET -k 'http://localhost:8080/api/v3/resource_status/resource:71df3086'
+
+{"code":0,"data":{"is_alive":true}}
 ```
 
 ### delete

--- a/include/rule_engine.hrl
+++ b/include/rule_engine.hrl
@@ -31,6 +31,10 @@
 
 -type(hook() :: atom() | 'any').
 
+-type(resource_status() :: #{ alive := boolean()
+                            , atom() => binary() | atom() | list(binary()|atom())
+                            }).
+
 -define(descr, #{en => <<>>, zh => <<>>}).
 
 -record(action,
@@ -67,6 +71,7 @@
         { id :: resource_id()
         , type :: resource_type_name()
         , config :: #{} %% the configs got from API for initializing resource
+        , created_at :: erlang:timestamp()
         , description :: binary()
         }).
 
@@ -75,6 +80,7 @@
         , provider :: atom()
         , params_spec :: #{atom() => term()} %% params specs
         , on_create :: mf()
+        , on_status :: mf()
         , on_destroy :: mf()
         , title = ?descr :: descr()
         , description = ?descr :: descr()

--- a/src/emqx_rule_engine_api.erl
+++ b/src/emqx_rule_engine_api.erl
@@ -256,8 +256,14 @@ do_create_resource(Create, Params) ->
         throw:{init_resource_failure, Reason} ->
             %% Note that we will return OK in case of resource creation failure,
             %% users can always re-start the resource later.
-            ?LOG(error, "[RuleEngineAPI] init_resource_failure: ~p", [Reason]),
-            return(ok);
+            case Create of
+                create_resource ->
+                    ?LOG(error, "[RuleEngineAPI] init_resource_failure: ~p", [Reason]),
+                    return(ok);
+                test_resource ->
+                    ?LOG(error, "[RuleEngineAPI] test_resource_failure: ~p", [Reason]),
+                    return({error, 500, <<"Test Creating Resource Failed">>})
+            end;
         throw:Reason ->
             return({error, 400, ?ERR_BADARGS(Reason)});
         _Error:Reason:StackT ->

--- a/src/emqx_rule_engine_api.erl
+++ b/src/emqx_rule_engine_api.erl
@@ -83,6 +83,13 @@
             descr  => "Show a resource"
            }).
 
+-rest_api(#{name   => get_resource_status,
+            method => 'GET',
+            path   => "/resource_status/:bin:id",
+            func   => get_resource_status,
+            descr  => "Get status of a resource"
+           }).
+
 -rest_api(#{name   => start_resource,
             method => 'POST',
             path   => "/resources/:bin:id",
@@ -131,6 +138,7 @@
 -export([ create_resource/2
         , list_resources/2
         , show_resource/2
+        , get_resource_status/2
         , start_resource/2
         , delete_resource/2
         ]).
@@ -265,6 +273,14 @@ list_resources_by_type(#{type := Type}, _Params) ->
 
 show_resource(#{id := Id}, _Params) ->
     reply_with(fun emqx_rule_registry:find_resource/1, Id).
+
+get_resource_status(#{id := Id}, _Params) ->
+    case emqx_rule_engine:get_resource_status(Id) of
+        {ok, Status} ->
+            return({ok, Status});
+        {error, {resource_not_found, ResId}} ->
+            return({error, 400, ?ERR_NO_RESOURCE(ResId)})
+    end.
 
 start_resource(#{id := Id}, _Params) ->
     try emqx_rule_engine:start_resource(Id) of

--- a/src/emqx_rule_engine_app.erl
+++ b/src/emqx_rule_engine_app.erl
@@ -27,8 +27,8 @@
 start(_Type, _Args) ->
     {ok, Sup} = emqx_rule_engine_sup:start_link(),
     ok = emqx_rule_engine:load_providers(),
-    ok = emqx_rule_engine:re_establish_resources(),
-    ok = emqx_rule_engine:rebuild_rules(),
+    ok = emqx_rule_engine:refresh_resources(),
+    ok = emqx_rule_engine:refresh_rules(),
     ok = emqx_rule_engine_cli:load(),
     ok = emqx_rule_runtime:start(env()),
     {ok, Sup}.


### PR DESCRIPTION
- Show a `restart/re-establish` button to establish resource connection if the status is connection down.

- `Resource Create` button is to store resource configs (persistently), and try to establish the connection for only one time. And we set status to connection down if connects to the database server failed.

- The `restart/re-establish` button is only to re-establish the connection for the current node, not for the whole cluster.

- If `restart/re-establish` button failure, errors should be showed on the dashboard.

- `Test (dry-run) connection` button is to test the connectivity, and shows the result. 
