### PR TITLE
Fix URL testing issue

### DIFF
--- a/src/emqx_rule_utils.erl
+++ b/src/emqx_rule_utils.erl
@@ -143,8 +143,12 @@ tcp_connectivity(Host, Port) ->
         {error, Reason} -> {error, Reason}
     end.
 
-default_port(http) -> 80;
-default_port(https) -> 443.
+default_port("http") -> 80;
+default_port("https") -> 443;
+default_port(<<"http">>) -> 80;
+default_port(<<"https">>) -> 443;
+default_port(Scheme) -> throw({bad_scheme, Scheme}).
+
 
 unwrap(<<"${", Val/binary>>) ->
     binary:part(Val, {0, byte_size(Val)-1}).


### PR DESCRIPTION
Fix the issue that test Urls without port number like "http://www.google.com" failed. 