### PR TITLE
fix(broadcast): cluster called the CLI node by mistake

### DIFF
--- a/src/emqx_rule_engine.appup.src
+++ b/src/emqx_rule_engine.appup.src
@@ -1,12 +1,14 @@
 {"4.2.1",
   [
     {"4.2.0", [
-      {load_module, emqx_rule_actions, brutal_purge, soft_purge, []}
+      {load_module, emqx_rule_actions, brutal_purge, soft_purge, []},
+      {load_module, emqx_rule_engine, brutal_purge, soft_purge, []}
     ]}
   ],
   [
     {"4.2.0", [
-      {load_module, emqx_rule_actions, brutal_purge, soft_purge, []}
+      {load_module, emqx_rule_actions, brutal_purge, soft_purge, []},
+      {load_module, emqx_rule_engine, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/src/emqx_rule_engine.erl
+++ b/src/emqx_rule_engine.erl
@@ -418,7 +418,7 @@ action_instance_id(ActionName) ->
     iolist_to_binary([atom_to_list(ActionName), "_", integer_to_list(erlang:system_time())]).
 
 cluster_call(Func, Args) ->
-    case rpc:multicall([node() | nodes()], ?MODULE, Func, Args, 5000) of
+    case rpc:multicall(ekka_mnesia:running_nodes(), ?MODULE, Func, Args, 5000) of
         {ResL, []} ->
             case lists:filter(fun(ok) -> false; (_) -> true end, ResL) of
                 [] -> ok;


### PR DESCRIPTION
```
2020-11-13 17:34:09.097 [error] cluster_call error found, ResL: [ok,
                                 {{init_module_failure,
                                   'emqx_upgrader_7365@127.0.0.1'},
                                  {{emqx_module_auth_sasl,on_module_create},
                                   {badmatch,
                                    {node_not_running,
                                     'emqx_upgrader_7365@127.0.0.1'}}}}]
```