### PR TITLE
fix(printable_maps): fix(printable_maps): add workaround for passing User-Property as pairs, not map

### DIFF
--- a/src/emqx_rule_engine.appup.src
+++ b/src/emqx_rule_engine.appup.src
@@ -1,6 +1,6 @@
 %% -*-: erlang -*-
 
-{"4.2.3",
+{VSN,
  [
    {"4.2.0", [
      {load_module, emqx_rule_events, brutal_purge, soft_purge, []},
@@ -19,7 +19,8 @@
      {load_module, emqx_rule_funcs, brutal_purge, soft_purge, []},
      {load_module, emqx_rule_engine, brutal_purge, soft_purge, []},
      {load_module, emqx_rule_actions, brutal_purge, soft_purge, []}
-   ]}
+   ]},
+   {<<".*">>, []}
  ],
  [
    {"4.2.0", [
@@ -39,6 +40,7 @@
      {load_module, emqx_rule_actions, brutal_purge, soft_purge, []},
      {load_module, emqx_rule_engine, brutal_purge, soft_purge, []},
      {load_module, emqx_rule_funcs, brutal_purge, soft_purge, []}
-   ]}
+   ]},
+   {<<".*">>, []}
  ]
 }.

--- a/src/emqx_rule_events.erl
+++ b/src/emqx_rule_events.erl
@@ -360,6 +360,12 @@ printable_maps(Headers) ->
         fun (K, V0, AccIn) when K =:= peerhost; K =:= peername; K =:= sockname ->
                 AccIn#{K => ntoa(V0)};
             ('User-Property', V0, AccIn) when is_list(V0) ->
-                AccIn#{'User-Property' => maps:from_list(V0)};
+                AccIn#{
+                    'User-Property' => maps:from_list(V0),
+                    'User-Property-Pairs' => [#{
+                        key => Key,
+                        value => Value
+                     } || {Key, Value} <- V0]
+                };
             (K, V0, AccIn) -> AccIn#{K => V0}
         end, #{}, Headers).


### PR DESCRIPTION
Hello!

This PR is tightly connected to this https://github.com/emqx/emqx/pull/3878, just removes workaround for User-Property.

Thank you!