### PR TITLE
Add more SQL funcs

### DIFF
--- a/include/rule_engine.hrl
+++ b/include/rule_engine.hrl
@@ -16,6 +16,8 @@
 
 -define(APP, emqx_rule_engine).
 
+-define(KV_TAB, '@rule_engine_db').
+
 -type(maybe(T) :: T | undefined).
 
 -type(rule_id() :: binary()).

--- a/src/emqx_rule_engine_app.erl
+++ b/src/emqx_rule_engine_app.erl
@@ -16,6 +16,8 @@
 
 -module(emqx_rule_engine_app).
 
+-include("rule_engine.hrl").
+
 -behaviour(application).
 
 -emqx_plugin(?MODULE).
@@ -24,9 +26,9 @@
 
 -export([stop/1]).
 
--define(APP, emqx_rule_engine).
-
 start(_Type, _Args) ->
+    ets:new(?KV_TAB, [named_table, set, public,
+        {write_concurrency, true}, {read_concurrency, true}]),
     {ok, Sup} = emqx_rule_engine_sup:start_link(),
     _ = emqx_rule_engine_sup:start_locker(),
     ok = emqx_rule_engine:load_providers(),

--- a/src/emqx_rule_funcs.erl
+++ b/src/emqx_rule_funcs.erl
@@ -171,6 +171,8 @@
         , base64_decode/1
         , json_decode/1
         , json_encode/1
+        , term_decode/1
+        , term_encode/1
         ]).
 
 %% Proc Dict Func
@@ -787,6 +789,12 @@ json_encode(Data) ->
 
 json_decode(Data) ->
     emqx_json:decode(Data, [return_maps]).
+
+term_encode(Term) ->
+    erlang:term_to_binary(Term).
+
+term_decode(Data) ->
+    erlang:binary_to_term(Data).
 
 %%------------------------------------------------------------------------------
 %% Dict Funcs

--- a/src/emqx_rule_funcs.erl
+++ b/src/emqx_rule_funcs.erl
@@ -91,6 +91,8 @@
         , int/1
         , float/1
         , map/1
+        , bin2hexstr/1
+        , hexstr2bin/1
         ]).
 
 %% Data Type Validation Funcs
@@ -499,6 +501,13 @@ float(Data) ->
 
 map(Data) ->
     emqx_rule_utils:map(Data).
+
+bin2hexstr(Bin) when is_binary(Bin) ->
+    IntL = binary_to_list(Bin),
+    list_to_binary([io_lib:format("~2.16.0B", [Int]) || Int <- IntL]).
+
+hexstr2bin(Str) when is_binary(Str) ->
+    list_to_binary([binary_to_integer(W, 16) || <<W:2/binary>> <= Str]).
 
 %%------------------------------------------------------------------------------
 %% NULL Funcs

--- a/src/emqx_rule_funcs.erl
+++ b/src/emqx_rule_funcs.erl
@@ -16,6 +16,8 @@
 
 -module(emqx_rule_funcs).
 
+-include("rule_engine.hrl").
+
 %% IoT Funcs
 -export([ msgid/0
         , qos/0
@@ -178,6 +180,9 @@
 %% Proc Dict Func
 -export([ proc_dict_get/1
         , proc_dict_put/2
+        , kv_store_get/1
+        , kv_store_get/2
+        , kv_store_put/2
         ]).
 
 %% Date functions
@@ -805,6 +810,17 @@ proc_dict_get(Key) ->
 
 proc_dict_put(Key, Val) ->
     erlang:put(?DICT_KEY(Key), Val).
+
+kv_store_put(Key, Val) ->
+    ets:insert(?KV_TAB, {Key, Val}).
+
+kv_store_get(Key) ->
+    kv_store_get(Key, undefined).
+kv_store_get(Key, Default) ->
+    case ets:lookup(?KV_TAB, Key) of
+        [{_, Val}] -> Val;
+        _ -> Default
+    end.
 
 %%--------------------------------------------------------------------
 %% Date functions

--- a/src/emqx_rule_funcs.erl
+++ b/src/emqx_rule_funcs.erl
@@ -171,6 +171,11 @@
         , json_encode/1
         ]).
 
+%% Proc Dict Func
+-export([ proc_dict_get/1
+        , proc_dict_put/2
+        ]).
+
 %% Date functions
 -export([ now_rfc3339/0
         , now_rfc3339/1
@@ -773,6 +778,16 @@ json_encode(Data) ->
 
 json_decode(Data) ->
     emqx_json:decode(Data, [return_maps]).
+
+%%------------------------------------------------------------------------------
+%% Dict Funcs
+%%------------------------------------------------------------------------------
+-define(DICT_KEY(KEY), {'@rule_engine', KEY}).
+proc_dict_get(Key) ->
+    erlang:get(?DICT_KEY(Key)).
+
+proc_dict_put(Key, Val) ->
+    erlang:put(?DICT_KEY(Key), Val).
 
 %%--------------------------------------------------------------------
 %% Date functions

--- a/test/emqx_rule_engine_SUITE.erl
+++ b/test/emqx_rule_engine_SUITE.erl
@@ -69,7 +69,9 @@ groups() ->
        t_resource_types_cli
       ]},
      {funcs, [],
-      [t_topic_func]},
+      [t_topic_func,
+       t_kv_store
+      ]},
      {registry, [sequence],
       [t_add_get_remove_rule,
        t_add_get_remove_rules,
@@ -556,6 +558,12 @@ t_resource_types_cli(_Config) ->
 t_topic_func(_Config) ->
     %%TODO:
     ok.
+
+t_kv_store(_) ->
+    undefined = emqx_rule_funcs:kv_store_get(<<"abc">>),
+    <<"not_found">> = emqx_rule_funcs:kv_store_get(<<"abc">>, <<"not_found">>),
+    emqx_rule_funcs:kv_store_put(<<"abc">>, 1),
+    1 = emqx_rule_funcs:kv_store_get(<<"abc">>, <<"not_found">>).
 
 %%------------------------------------------------------------------------------
 %% Test cases for rule registry

--- a/test/emqx_rule_funcs_SUITE.erl
+++ b/test/emqx_rule_funcs_SUITE.erl
@@ -143,6 +143,14 @@ t_bool(_) ->
     ?assertEqual(false, emqx_rule_funcs:bool(<<"false">>)),
     ?assertError({invalid_boolean, _}, emqx_rule_funcs:bool(3)).
 
+t_hexstr2bin(_) ->
+    ?assertEqual(<<1,2>>, emqx_rule_funcs:hexstr2bin(<<"0102">>)),
+    ?assertEqual(<<17,33>>, emqx_rule_funcs:hexstr2bin(<<"1121">>)).
+
+t_bin2hexstr(_) ->
+    ?assertEqual(<<"0102">>, emqx_rule_funcs:bin2hexstr(<<1,2>>)),
+    ?assertEqual(<<"1121">>, emqx_rule_funcs:bin2hexstr(<<17,33>>)).
+
 t_is_null(_) ->
     ?assertEqual(true, emqx_rule_funcs:is_null(undefined)),
     ?assertEqual(false, emqx_rule_funcs:is_null(a)),
@@ -278,6 +286,18 @@ prop_bits_op() ->
                 (X bxor Y) == apply_func(bitxor, [X, Y]) andalso
                 (X bsl Y) == apply_func(bitsl, [X, Y]) andalso
                 (X bsr Y) == apply_func(bitsr, [X, Y])
+            end).
+
+t_hex_convert(_) ->
+    ?PROPTEST(hex_convert).
+
+hex_convert() ->
+    ?FORALL(L, list(range(0, 255)),
+            begin
+                AbitraryBin = list_to_binary(L),
+                io:format("----~p~n", [AbitraryBin]),
+                AbitraryBin == emqx_rule_funcs:hexstr2bin(
+                    emqx_rule_funcs:bin2hexstr(AbitraryBin))
             end).
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
- conversions between hex_string and binary
- term_to_binary and binary_to_term (useful when we want to avoid json_decode parses binaries as UTF-8 strings
- erlang:put/2 and erlang:get/1 (useful when we need to maintain states in current connection process)