### PR TITLE
fix(rule): destroy the actions when disabling the rule

### DIFF
--- a/src/emqx_rule_engine.erl
+++ b/src/emqx_rule_engine.erl
@@ -382,9 +382,14 @@ may_update_rule_params(Rule, Params = #{rawsql := SQL}) ->
                 maps:remove(rawsql, Params));
         Error -> error(Error)
     end;
-may_update_rule_params(Rule, Params = #{enabled := Enabled}) ->
-    Enabled andalso refresh_rule(Rule),
-    may_update_rule_params(Rule#rule{enabled = Enabled}, maps:remove(enabled, Params));
+may_update_rule_params(Rule = #rule{enabled = OldE, actions = Actions},
+        Params = #{enabled := ToE}) ->
+    case {OldE, ToE} of
+        {false, true} -> refresh_rule(Rule);
+        {true, false} -> clear_actions(Actions);
+        _ -> ok
+    end,
+    may_update_rule_params(Rule#rule{enabled = ToE}, maps:remove(enabled, Params));
 may_update_rule_params(Rule, Params = #{description := Descr}) ->
     may_update_rule_params(Rule#rule{description = Descr}, maps:remove(description, Params));
 may_update_rule_params(Rule, Params = #{on_action_failed := OnFailed}) ->

--- a/test/emqx_rule_engine_SUITE.erl
+++ b/test/emqx_rule_engine_SUITE.erl
@@ -75,6 +75,7 @@ groups() ->
        t_add_get_remove_rules,
        t_create_existing_rule,
        t_update_rule,
+       t_disable_rule,
        t_get_rules_for,
        t_get_rules_for_2,
        t_add_get_remove_action,
@@ -639,6 +640,48 @@ t_update_rule(_Config) ->
     ok = emqx_rule_engine:delete_rule(<<"an_existing_rule">>),
     ?assertEqual(not_found, emqx_rule_registry:get_rule(<<"an_existing_rule">>)),
     ok.
+
+t_disable_rule(_Config) ->
+    ets:new(simpile_action_2, [named_table, set, public]),
+    ets:insert(simpile_action_2, {created, 0}),
+    ets:insert(simpile_action_2, {destroyed, 0}),
+    Now = erlang:timestamp(),
+    emqx_rule_registry:add_action(
+        #action{name = 'simpile_action_2', app = ?APP,
+                module = ?MODULE,
+                on_create = simpile_action_2_create,
+                on_destroy = simpile_action_2_destroy,
+                types=[], params_spec = #{},
+                title = #{en => <<"Simple Action">>},
+                description = #{en => <<"Simple Action">>}}),
+    {ok, #rule{actions = [#action_instance{id = ActInsId0}]}} = emqx_rule_engine:create_rule(
+        #{id => <<"simple_rule_2">>,
+          rawsql => <<"select * from \"t/#\"">>,
+          actions => [#{name => 'simpile_action_2', args => #{}}]
+        }),
+    [{_, CAt}] = ets:lookup(simpile_action_2, created),
+    ?assert(CAt > Now),
+    [{_, DAt}] = ets:lookup(simpile_action_2, destroyed),
+    ?assert(DAt < Now),
+
+    %% disable the rule and verify the old action instances has been cleared
+    Now2 = erlang:timestamp(),
+    emqx_rule_engine:update_rule(#{ id => <<"simple_rule_2">>,
+                                    enabled => false}),
+    [{_, CAt2}] = ets:lookup(simpile_action_2, created),
+    ?assert(CAt2 < Now2),
+    [{_, DAt2}] = ets:lookup(simpile_action_2, destroyed),
+    ?assert(DAt2 > Now2),
+
+    %% enable the rule again and verify the action instances has been created
+    Now3 = erlang:timestamp(),
+    emqx_rule_engine:update_rule(#{ id => <<"simple_rule_2">>,
+                                    enabled => true}),
+    [{_, CAt3}] = ets:lookup(simpile_action_2, created),
+    ?assert(CAt3 > Now3),
+    [{_, DAt3}] = ets:lookup(simpile_action_2, destroyed),
+    ?assert(DAt3 < Now3),
+    ok = emqx_rule_engine:delete_rule(<<"simple_rule_2">>).
 
 t_get_rules_for(_Config) ->
     Len0 = length(emqx_rule_registry:get_rules_for(<<"simple/topic">>)),
@@ -2117,6 +2160,14 @@ crash_action(_Id, _Params) ->
         ct:pal("applying crash action, Data: ~p", [Data]),
         1/0
     end.
+
+simpile_action_2_create(_Id, _Params) ->
+    ets:insert(simpile_action_2, {created, erlang:timestamp()}),
+    fun(_Data, _Envs) -> ok end.
+
+simpile_action_2_destroy(_Id, _Params) ->
+    ets:insert(simpile_action_2, {destroyed, erlang:timestamp()}),
+    fun(_Data, _Envs) -> ok end.
 
 init_plus_by_one_action() ->
     ets:new(plus_by_one_action, [named_table, set, public]),


### PR DESCRIPTION

Currently we only delete an action when we delete the rule associated to it.
But some actions like Kafka will also create connections that need to be deleted when disabling the rule. 

This PR fix the issue.